### PR TITLE
Sum conflict numbers in metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,9 +54,12 @@ func main() {
 		sumConflicts := 0
 
 		for _, numbers := range hostnameConflicts {
-			conflicts := len(numbers)
-			if _, ok := numbers[0]; ok {
-				conflicts--
+			conflicts := 0
+			for num := range numbers {
+				if num == 0 {
+					continue
+				}
+				conflicts += num
 			}
 			sumConflicts += conflicts
 			for i, bound := range bucketBounds {


### PR DESCRIPTION
## Summary
- Sum conflict numbers instead of counting them when creating metrics

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c77963763483269078dbcef70822c5