### PR TITLE
Sum conflict numbers for metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,9 +54,11 @@ func main() {
 		sumConflicts := 0
 
 		for _, numbers := range hostnameConflicts {
-			conflicts := len(numbers)
-			if _, ok := numbers[0]; ok {
-				conflicts--
+			conflicts := 0
+			for num := range numbers {
+				if num != 0 {
+					conflicts += num
+				}
 			}
 			sumConflicts += conflicts
 			for i, bound := range bucketBounds {


### PR DESCRIPTION
## Summary
- compute conflict metrics using the sum of conflict numbers instead of the count

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c77963763483269078dbcef70822c5